### PR TITLE
Prepare for version `0.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.0.1] - 2024-08-09
 
 ### Changed
 
@@ -20,4 +20,5 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Workflow to create/draft releases after pre-release PR merge
 - "Dogfood" workflows to self-manage this repository's releases
 
+[0.0.1]: https://github.com/uclahs-cds/tool-create-release/compare/v0.0.1-rc.1...v0.0.1
 [0.0.1-rc.1]: https://github.com/uclahs-cds/tool-create-release/releases/tag/v0.0.1-rc.1


### PR DESCRIPTION
Update CHANGELOG in preparation for release **0.0.1**.

Merging this PR will trigger another workflow to create the release tag **v0.0.1**.

| Input | Value |
| ----- | ----- |
| Actor | @nwiltsie |
| Branch | `main` |
| Bump Type | `patch` |
