### PR TITLE
Add instructions for README badges, update templates to major alias

### DIFF
--- a/.github/workflows/internal-finalize.yaml
+++ b/.github/workflows/internal-finalize.yaml
@@ -20,5 +20,3 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'automation-create-release') }}
     uses: ./.github/workflows/wf-finalize-release.yaml
     secrets: inherit
-    with:
-      draft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add badge linking to release workflow to README
+- Add instructions for README badges to README
+
+### Changed
+
+- Comment out `draft` parameter in template
+- Update template to refer to `v1` rather than `v1.0.0`
+
 ## [1.0.0] - 2024-10-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * [Parameters](#parameters)
   + [Updating hard-coded strings with `version_files`](#updating-hard-coded-strings-with-version_files)
 
-This set of reusable workflows manage the complexity of creating and tagging new software releases on GitHub.
+This set of reusable workflows manages the complexity of creating and tagging new software releases on GitHub.
 
 ## Versioning Standards
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can add a badge that links to the release preparation workflow by including 
 ```
 
 #### Private / Internal Repository
-[![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/uclahs-cds/tool-submit-nf/actions/workflows/internal-prepare.yaml)
+[![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/uclahs-cds/tool-create-release/actions/workflows/internal-prepare.yaml)
 ```
 [![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/ORG/REPO/actions/workflows/internal-prepare.yaml)
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Automations for GitHub Releases
 
+[![GitHub release](https://img.shields.io/github/v/release/uclahs-cds/tool-create-release)](https://github.com/uclahs-cds/tool-create-release/actions/workflows/internal-prepare.yaml)
+
+* [Versioning Standards](#versioning-standards)
+* [Usage](#usage)
+  * [README Badges](#readme-badges)
+* [Parameters](#parameters)
+  + [Updating hard-coded strings with `version_files`](#updating-hard-coded-strings-with-version_files)
+
 This set of reusable workflows manage the complexity of creating and tagging new software releases on GitHub.
 
 ## Versioning Standards
@@ -74,6 +82,22 @@ Usage of this tool requires adding three workflows to each calling repository (n
 
         checkout main
         merge prepare_patch tag: "v1" tag: "v1.0.1"
+```
+
+### README Badges
+
+You can add a badge that links to the release preparation workflow by including one of these Markdown snippets (after replacing `ORG` and `REPO`) to your README:
+
+#### Public Repository
+[![GitHub release](https://img.shields.io/github/v/release/uclahs-cds/tool-create-release)](https://github.com/uclahs-cds/tool-create-release/actions/workflows/internal-prepare.yaml)
+```
+[![GitHub release](https://img.shields.io/github/v/release/ORG/REPO)](https://github.com/ORG/REPO/actions/workflows/prepare-release.yaml)
+```
+
+#### Private / Internal Repository
+[![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/uclahs-cds/tool-submit-nf/actions/workflows/internal-prepare.yaml)
+```
+[![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/ORG/REPO/actions/workflows/internal-prepare.yaml)
 ```
 
 ## Parameters

--- a/templates/alias-release.yaml
+++ b/templates/alias-release.yaml
@@ -15,6 +15,5 @@ permissions:
 
 jobs:
   update-alias:
-    uses: uclahs-cds/tool-create-release/.github/workflows/wf-alias-release.yaml@v1.0.0
-    # Secrets are only required until tool-create-release is made public
+    uses: uclahs-cds/tool-create-release/.github/workflows/wf-alias-release.yaml@v1
     secrets: inherit

--- a/templates/finalize-release.yaml
+++ b/templates/finalize-release.yaml
@@ -18,8 +18,8 @@ permissions:
 jobs:
   finalize-release:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'automation-create-release') }}
-    uses: uclahs-cds/tool-create-release/.github/workflows/wf-finalize-release.yaml@v1.0.0
-    with:
-      draft: true
-    # Secrets are only required until tool-create-release is made public
+    uses: uclahs-cds/tool-create-release/.github/workflows/wf-finalize-release.yaml@v1
     secrets: inherit
+    # Uncomment these lines to draft the release rather than of publishing
+    # with:
+    #   draft: true

--- a/templates/prepare-release-non-semantic-version.yaml
+++ b/templates/prepare-release-non-semantic-version.yaml
@@ -18,9 +18,8 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: uclahs-cds/tool-create-release/.github/workflows/wf-prepare-release.yaml@v1.0.0
+    uses: uclahs-cds/tool-create-release/.github/workflows/wf-prepare-release.yaml@v1
     with:
       bump_type: "exact"
       exact_version: ${{ inputs.version }}
-    # Secrets are only required until tool-create-release is made public
     secrets: inherit

--- a/templates/prepare-release.yaml
+++ b/templates/prepare-release.yaml
@@ -25,9 +25,8 @@ permissions:
 
 jobs:
   prepare-release:
-    uses: uclahs-cds/tool-create-release/.github/workflows/wf-prepare-release.yaml@v1.0.0
+    uses: uclahs-cds/tool-create-release/.github/workflows/wf-prepare-release.yaml@v1
     with:
       bump_type: ${{ inputs.bump_type }}
       prerelease: ${{ inputs.prerelease }}
-    # Secrets are only required until tool-create-release is made public
     secrets: inherit


### PR DESCRIPTION
# Description
This adds a fancy badge to the README showing the current GitHub release and linking to the release workflow:

[![GitHub release](https://img.shields.io/github/v/release/uclahs-cds/tool-create-release)](https://github.com/uclahs-cds/tool-create-release/actions/workflows/internal-prepare.yaml)

It also adds instructions on how to add matching badges to calling repositories. Two points of frustration there:
* You have to fill in the absolute URL to the workflow; anything relative won't work.
* Public repositories can use the [shields.io GitHub release badge](https://shields.io/badges/git-hub-release), but private/internal repositories are limited to a [simpler static badge](https://shields.io/badges/static-badge):

[![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/uclahs-cds/tool-create-release/actions/workflows/internal-prepare.yaml)

Finally, I cleaned up the template workflows:

* I removed all of the `Secrets are only required until...` comments. It's just easier to keep using secrets.
* I commented-out the `draft` parameter to the finalization workflow. Users copying the template can easily uncomment it, but it makes the drafting behavior opt-in.
* I changed the workflow versions from `v1.0.0` to `v1`. That'll eliminate the need for dependabot to bump anything except major versions. This is safe because it's our own workflow; any non-`uclahs-cds` users of these workflows should stick with the full version.


### Closes #11

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
