### PR TITLE
Properly handle drafting being opt-in, fix private badge template

### DIFF
--- a/.github/workflows/internal-finalize.yaml
+++ b/.github/workflows/internal-finalize.yaml
@@ -20,3 +20,5 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'automation-create-release') }}
     uses: ./.github/workflows/wf-finalize-release.yaml
     secrets: inherit
+    with:
+      draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Set `draft` parameter in template to `false`
+
+### Fixed
+
+- Corrected private repository badge template in README
+
 ## [1.0.1] - 2024-10-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Corrected private repository badge template in README
+- Correct private repository badge template in README
 
 ## [1.0.1] - 2024-10-18
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can add a badge that links to the release preparation workflow by including 
 #### Private / Internal Repository
 [![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/uclahs-cds/tool-create-release/actions/workflows/internal-prepare.yaml)
 ```
-[![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/ORG/REPO/actions/workflows/internal-prepare.yaml)
+[![Prepare release](https://img.shields.io/badge/Action-Create%20New%20Release-blue)](https://github.com/ORG/REPO/actions/workflows/prepare-release.yaml)
 ```
 
 ## Parameters

--- a/templates/finalize-release.yaml
+++ b/templates/finalize-release.yaml
@@ -20,6 +20,5 @@ jobs:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'automation-create-release') }}
     uses: uclahs-cds/tool-create-release/.github/workflows/wf-finalize-release.yaml@v1
     secrets: inherit
-    # Uncomment these lines to draft the release rather than of publishing
-    # with:
-    #   draft: true
+    with:
+      draft: false


### PR DESCRIPTION
# Description
So I was _completely_ wrong when I said this in #20:

> Users copying the template can easily uncomment it, but it makes the drafting behavior opt-in.

Drafting was and remains opt-**out** (which does feel like the safer choice in general). This PR adds in `draft: false` to do what I _meant_ to do with #20.

I also managed to mess up one of the badge templates. For background, this repository intentionally has non-standard release workflows to ensure it uses the "current" reusables rather than re-cloning itself (like all other repositories have to do). In order to avoid confusion I named _these_ workflows `internal-{verb}.yaml` instead of `{verb}-release.yaml`, but I've ended up confusing myself anyway.

Regardless, the badge markdown template in the README now refers to the same workflow name as in the templates directory.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
