### PR TITLE
Explicitly manage secrets, add capability to attach source tarball

### DIFF
--- a/.github/workflows/internal-alias.yaml
+++ b/.github/workflows/internal-alias.yaml
@@ -16,5 +16,3 @@ permissions:
 jobs:
   update-alias:
     uses: ./.github/workflows/wf-alias-release.yaml
-    # Secrets are only required until tool-create-release is made public
-    secrets: inherit

--- a/.github/workflows/internal-finalize.yaml
+++ b/.github/workflows/internal-finalize.yaml
@@ -19,6 +19,7 @@ jobs:
   finalize-release:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'automation-create-release') }}
     uses: ./.github/workflows/wf-finalize-release.yaml
-    secrets: inherit
     with:
       draft: false
+    secrets:
+      token: ${{ secrets.UCLAHS_CDS_REPO_READ_TOKEN }}

--- a/.github/workflows/internal-prepare.yaml
+++ b/.github/workflows/internal-prepare.yaml
@@ -29,5 +29,5 @@ jobs:
     with:
       bump_type: ${{ inputs.bump_type }}
       prerelease: ${{ inputs.prerelease }}
-    # Secrets are only required until tool-create-release is made public
-    secrets: inherit
+    secrets:
+      token: ${{ secrets.UCLAHS_CDS_REPO_READ_TOKEN }}

--- a/.github/workflows/wf-alias-release.yaml
+++ b/.github/workflows/wf-alias-release.yaml
@@ -3,12 +3,12 @@ on:
   workflow_call:
     inputs:
       # These inputs are taken directly from stefanzweifel/git-auto-commit-action
-      commit_user_name:
+      commit-user-name:
         type: string
         description: Name used for the commit user
         required: false
         default: github-actions[bot]
-      commit_user_email:
+      commit-user-email:
         type: string
         description: Email address used for the commit user
         required: false
@@ -71,5 +71,5 @@ jobs:
         env:
           REPO_DIR: caller
           GH_TOKEN: ${{ secrets.token || github.token }}
-          COMMIT_USER: ${{ inputs.commit_user_name }}
-          COMMIT_EMAIL: ${{ inputs.commit_user_email }}
+          COMMIT_USER: ${{ inputs.commit-user-name }}
+          COMMIT_EMAIL: ${{ inputs.commit-user-email }}

--- a/.github/workflows/wf-alias-release.yaml
+++ b/.github/workflows/wf-alias-release.yaml
@@ -1,6 +1,24 @@
 ---
 on:
   workflow_call:
+    inputs:
+      # These inputs are taken directly from stefanzweifel/git-auto-commit-action
+      commit_user_name:
+        type: string
+        description: Name used for the commit user
+        required: false
+        default: github-actions[bot]
+      commit_user_email:
+        type: string
+        description: Email address used for the commit user
+        required: false
+        default: 41898282+github-actions[bot]@users.noreply.github.com
+    secrets:
+      token:
+        description: >
+          Personal access token (PAT) used to fetch the repository. Required
+          if the repository has any private submodules.
+        required: false
 
 jobs:
   alias-release:
@@ -14,7 +32,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.token || github.token }}
         run: |
           ACTION_DATA=$(gh api "repos/$REPO/actions/runs/$RUN_ID")
           echo "::debug::$ACTION_DATA"
@@ -27,7 +45,6 @@ jobs:
           repository: uclahs-cds/tool-create-release
           path: reusable
           ref: ${{ steps.workflow-parsing.outputs.SHA }}
-          token: ${{ secrets.UCLAHS_CDS_REPO_READ_TOKEN }}
 
       - name: Checkout calling repository
         uses: actions/checkout@v4
@@ -35,6 +52,7 @@ jobs:
           path: caller
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ secrets.token || github.token }}
 
       - name: Set up python
         uses: actions/setup-python@v5
@@ -47,9 +65,11 @@ jobs:
       # Update the alias if necessary
       - id: alias-release
         run: |
-          git config --file "$REPO_DIR/.git/config" user.name "github-actions[bot]"
-          git config --file "$REPO_DIR/.git/config" user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --file "$REPO_DIR/.git/config" user.name "$COMMIT_USER"
+          git config --file "$REPO_DIR/.git/config" user.email "$COMMIT_EMAIL"
           alias-release "$REPO_DIR" "$GITHUB_REF"
         env:
           REPO_DIR: caller
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.token || github.token }}
+          COMMIT_USER: ${{ inputs.commit_user_name }}
+          COMMIT_EMAIL: ${{ inputs.commit_user_email }}

--- a/.github/workflows/wf-finalize-release.yaml
+++ b/.github/workflows/wf-finalize-release.yaml
@@ -44,7 +44,6 @@ jobs:
           repository: uclahs-cds/tool-create-release
           path: reusable
           ref: ${{ steps.workflow-parsing.outputs.SHA }}
-          token: ${{ secrets.token || github.token }}
 
       - name: Set up python
         uses: actions/setup-python@v5

--- a/.github/workflows/wf-finalize-release.yaml
+++ b/.github/workflows/wf-finalize-release.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Establish variables for tarball attachment
         id: set-repo-name
-        if: ${{ inputs.attach-tarball == 'true' }}
+        if: ${{ inputs.attach-tarball }}
         env:
           RELEASE_TAG: ${{ steps.finalize-release.outputs.RELEASE_TAG }}
         run: |
@@ -75,14 +75,14 @@ jobs:
           echo "SOURCE_TARBALL=$REPO_NAME-$RELEASE_TAG.tar.gz" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
-        if: ${{ inputs.attach-tarball == 'true' }}
+        if: ${{ inputs.attach-tarball }}
         with:
           path: ${{ steps.set-repo-name.outputs.REPO_NAME }}
           submodules: 'recursive'
           token: ${{ secrets.token || github.token }}
 
       - name: Attach source tarball with submodules to release
-        if: ${{ inputs.attach-tarball == 'true' }}
+        if: ${{ inputs.attach-tarball }}
         env:
           RELEASE_TAG: ${{ steps.finalize-release.outputs.RELEASE_TAG }}
           REPO_NAME: ${{ steps.set-repo-name.outputs.REPO_NAME }}

--- a/.github/workflows/wf-finalize-release.yaml
+++ b/.github/workflows/wf-finalize-release.yaml
@@ -54,43 +54,29 @@ jobs:
       # Install the bundled package
       - run: pip install ./reusable
 
+      - name: Establish variables for tarball attachment
+        id: set-repo-name
+        run: |
+          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          echo "REPO_NAME=$REPO_NAME" >> "$GITHUB_OUTPUT"
+          mkdir source
+          echo "CLONE_PATH=source/$REPO_NAME" >> "$GITHUB_OUTPUT"
+
+      # Only check out the calling repository if we're going to attach a
+      # tarball to the release
+      - name: Clone repository to create tarball
+        uses: actions/checkout@v4
+        if: ${{ inputs.attach-tarball }}
+        with:
+          path: ${{ steps.set-repo-name.outputs.CLONE_PATH }}
+          submodules: 'recursive'
+          token: ${{ secrets.token || github.token }}
+
       - name: Finalize release
         id: finalize-release
-        run: finalize-release "$DRAFT"
+        run: finalize-release "$DRAFT" --archival-path "$CLONE_PATH"
         env:
           DRAFT: ${{ inputs.draft }}
           # Use the other token to allow the aliasing workflow to run
           GH_TOKEN: ${{ secrets.token || github.token }}
-
-      # The following steps are all gated behind inputs.attach-tarball being true
-
-      - name: Establish variables for tarball attachment
-        id: set-repo-name
-        if: ${{ inputs.attach-tarball }}
-        env:
-          RELEASE_TAG: ${{ steps.finalize-release.outputs.RELEASE_TAG }}
-        run: |
-          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-          echo "REPO_NAME=$REPO_NAME" >> "$GITHUB_OUTPUT"
-          echo "SOURCE_TARBALL=$REPO_NAME-$RELEASE_TAG.tar.gz" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@v4
-        if: ${{ inputs.attach-tarball }}
-        with:
-          path: ${{ steps.set-repo-name.outputs.REPO_NAME }}
-          submodules: 'recursive'
-          token: ${{ secrets.token || github.token }}
-
-      - name: Attach source tarball with submodules to release
-        if: ${{ inputs.attach-tarball }}
-        env:
-          RELEASE_TAG: ${{ steps.finalize-release.outputs.RELEASE_TAG }}
-          REPO_NAME: ${{ steps.set-repo-name.outputs.REPO_NAME }}
-          SOURCE_TARBALL: ${{ steps.set-repo-name.outputs.SOURCE_TARBALL }}
-          GH_TOKEN: ${{ secrets.token || github.token }}
-        run: |
-          tar --exclude-vcs -czvf "$SOURCE_TARBALL" "$REPO_NAME"
-          gh release upload \
-            --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_TAG" \
-            "$SOURCE_TARBALL#Source code with submodules (tar.gz)"
+          CLONE_PATH: ${{ steps.set-repo-name.outputs.CLONE_PATH }}

--- a/.github/workflows/wf-finalize-release.yaml
+++ b/.github/workflows/wf-finalize-release.yaml
@@ -6,6 +6,16 @@ on:
         description: If true (the default), draft the release for later manual approval.
         type: boolean
         default: true
+      attach-tarball:
+        description: If true, attach a tarball including all submodules to the release.
+        type: boolean
+        default: false
+      token:
+        description: >
+          Personal access token (PAT) used to fetch the repository and submodules.
+          Required if `draft` is false (to allow triggering alias workflow) or if
+          `attach-tarball` is true _and_ one or more of the submodules are private.
+        type: string
 
 jobs:
   finalize-release:
@@ -19,7 +29,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.token || github.token }}
         run: |
           ACTION_DATA=$(gh api "repos/$REPO/actions/runs/$RUN_ID")
           echo "::debug::$ACTION_DATA"
@@ -32,7 +42,7 @@ jobs:
           repository: uclahs-cds/tool-create-release
           path: reusable
           ref: ${{ steps.workflow-parsing.outputs.SHA }}
-          token: ${{ secrets.UCLAHS_CDS_REPO_READ_TOKEN }}
+          token: ${{ inputs.token || github.token }}
 
       - name: Set up python
         uses: actions/setup-python@v5
@@ -43,8 +53,42 @@ jobs:
       - run: pip install ./reusable
 
       - name: Finalize release
+        id: finalize-release
         run: finalize-release "$DRAFT"
         env:
           DRAFT: ${{ inputs.draft }}
           # Use the other token to allow the aliasing workflow to run
-          GH_TOKEN: ${{ secrets.UCLAHS_CDS_REPO_READ_TOKEN }}
+          GH_TOKEN: ${{ inputs.token || github.token }}
+
+      # The following steps are all gated behind inputs.attach-tarball being true
+
+      - name: Establish variables for tarball attachment
+        id: set-repo-name
+        if: ${{ inputs.attach-tarball == 'true' }}
+        env:
+          RELEASE_TAG: ${{ steps.finalize-release.outputs.RELEASE_TAG }}
+        run: |
+          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          echo "REPO_NAME=$REPO_NAME" >> "$GITHUB_OUTPUT"
+          echo "SOURCE_TARBALL=$REPO_NAME-$RELEASE_TAG.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        if: ${{ inputs.attach-tarball == 'true' }}
+        with:
+          path: ${{ steps.set-repo-name.outputs.REPO_NAME }}
+          submodules: 'recursive'
+          token: ${{ inputs.token || github.token }}
+
+      - name: Attach source tarball with submodules to release
+        if: ${{ inputs.attach-tarball == 'true' }}
+        env:
+          RELEASE_TAG: ${{ steps.finalize-release.outputs.RELEASE_TAG }}
+          REPO_NAME: ${{ steps.set-repo-name.outputs.REPO_NAME }}
+          SOURCE_TARBALL: ${{ steps.set-repo-name.outputs.SOURCE_TARBALL }}
+          GH_TOKEN: ${{ inputs.token || github.token }}
+        run: |
+          tar --exclude-vcs -czvf "$SOURCE_TARBALL" "$REPO_NAME"
+          gh release upload \
+            --repo "$GITHUB_REPOSITORY" \
+            "$RELEASE_TAG" \
+            "$SOURCE_TARBALL#Source code with submodules (tar.gz)"

--- a/.github/workflows/wf-finalize-release.yaml
+++ b/.github/workflows/wf-finalize-release.yaml
@@ -10,12 +10,14 @@ on:
         description: If true, attach a tarball including all submodules to the release.
         type: boolean
         default: false
+
+    secrets:
       token:
         description: >
           Personal access token (PAT) used to fetch the repository and submodules.
           Required if `draft` is false (to allow triggering alias workflow) or if
           `attach-tarball` is true _and_ one or more of the submodules are private.
-        type: string
+        required: false
 
 jobs:
   finalize-release:
@@ -29,7 +31,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
-          GH_TOKEN: ${{ inputs.token || github.token }}
+          GH_TOKEN: ${{ secrets.token || github.token }}
         run: |
           ACTION_DATA=$(gh api "repos/$REPO/actions/runs/$RUN_ID")
           echo "::debug::$ACTION_DATA"
@@ -42,7 +44,7 @@ jobs:
           repository: uclahs-cds/tool-create-release
           path: reusable
           ref: ${{ steps.workflow-parsing.outputs.SHA }}
-          token: ${{ inputs.token || github.token }}
+          token: ${{ secrets.token || github.token }}
 
       - name: Set up python
         uses: actions/setup-python@v5
@@ -58,7 +60,7 @@ jobs:
         env:
           DRAFT: ${{ inputs.draft }}
           # Use the other token to allow the aliasing workflow to run
-          GH_TOKEN: ${{ inputs.token || github.token }}
+          GH_TOKEN: ${{ secrets.token || github.token }}
 
       # The following steps are all gated behind inputs.attach-tarball being true
 
@@ -77,7 +79,7 @@ jobs:
         with:
           path: ${{ steps.set-repo-name.outputs.REPO_NAME }}
           submodules: 'recursive'
-          token: ${{ inputs.token || github.token }}
+          token: ${{ secrets.token || github.token }}
 
       - name: Attach source tarball with submodules to release
         if: ${{ inputs.attach-tarball == 'true' }}
@@ -85,7 +87,7 @@ jobs:
           RELEASE_TAG: ${{ steps.finalize-release.outputs.RELEASE_TAG }}
           REPO_NAME: ${{ steps.set-repo-name.outputs.REPO_NAME }}
           SOURCE_TARBALL: ${{ steps.set-repo-name.outputs.SOURCE_TARBALL }}
-          GH_TOKEN: ${{ inputs.token || github.token }}
+          GH_TOKEN: ${{ secrets.token || github.token }}
         run: |
           tar --exclude-vcs -czvf "$SOURCE_TARBALL" "$REPO_NAME"
           gh release upload \

--- a/.github/workflows/wf-prepare-release.yaml
+++ b/.github/workflows/wf-prepare-release.yaml
@@ -28,9 +28,21 @@ on:
         required: false
       version_files:
         type: string
-        description: Comma-separated list of relative paths to files with version numbers that should be updated. Every file must have exactly one line that looks like `version = "xxxx"` - some effort is made to handle different quoting styles, leading underscores, etc.
+        description: >
+          Comma-separated list of relative paths to files with version numbers
+          that should be updated. Every file must have exactly one line that
+          looks like `version = "xxxx"` - some effort is made to handle
+          different quoting styles, leading underscores, etc.
         required: false
         default: ""
+
+    secrets:
+      token:
+        description: >
+          Personal access token (PAT) used to open the pull request. Must be
+          provided in order for any actions to run in response to the PR
+          creation.
+        required: false
 
 jobs:
   prepare-release:
@@ -50,7 +62,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.token || github.token }}
         run: |
           ACTION_DATA=$(gh api "repos/$REPO/actions/runs/$RUN_ID")
           echo "::debug::$ACTION_DATA"
@@ -63,7 +75,6 @@ jobs:
           repository: uclahs-cds/tool-create-release
           path: reusable
           ref: ${{ steps.workflow-parsing.outputs.SHA }}
-          token: ${{ secrets.UCLAHS_CDS_REPO_READ_TOKEN }}
 
       - name: Checkout calling repository
         uses: actions/checkout@v4
@@ -104,7 +115,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.UCLAHS_CDS_REPO_READ_TOKEN }}
+          token: ${{ secrets.token || github.token }}
           path: caller
           add-paths: ${{ inputs.changelog }},${{ inputs.version_files }}
           commit-message: ${{ steps.bump-changelog.outputs.commit_message }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add `attach-tarball` argument to finalize workflow to attach source tarball with release
+
+### Changed
+
+- Remove hard-coded UCLA secrets, add explicit `secrets` inputs to workflows
+
 ## [1.0.3] - 2024-11-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Usage of this tool requires adding three workflows to each calling repository (n
 
 1. Create a new release with auto-generated notes and the target tag.
   * By default the new release is a draft, so no public release or tag are created without user intervention.
+1. Optionally, attach a source tarball including all submodules to the new release.
 1. Comment on the release PR with a link to the new release.
 
 ```mermaid
@@ -113,7 +114,14 @@ Parameters can be specified using the [`with`](https://docs.github.com/en/action
 | `wf-prepare-release.yaml` | `changelog` | string | no | Relative path to the CHANGELOG file. Defaults to `./CHANGELOG.md`. |
 | `wf-prepare-release.yaml` | `timezone` | string | no | IANA timezone to use when calculating the current date for the CHANGELOG. Defaults to `America/Los_Angeles`. |
 | `wf-finalize-release.yaml` | `draft` | boolean | no | If true (the default), mark the new release as a draft and require manual intervention to continue. |
+| `wf-finalize-release.yaml` | `attach-tarball` | boolean | no | If true (not the default), attach a tarball of the repository source, including all submodules, to the release. |
+| `wf-alias-release.yaml` | `commit_user_name` | string | no | User name to use while tagging new commits (defaults to `github-actions[bot]`) |
+| `wf-alias-release.yaml` | `commit_user_email` | string | no | User email to use while tagging new commits (defaults to `41898282+github-actions[bot]@users.noreply.github.com`) |
 
+All four workflows also accept a `token` secret which is required for full functionality (e.g. CI/CD checks on the opened pull request). The provided [personal access token](https://github.com/settings/tokens/new) should be stored as a secret in the repository and have the following scopes:
+
+* `repo`
+* `workflow`
 
 ### Updating hard-coded strings with `version_files`
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Parameters can be specified using the [`with`](https://docs.github.com/en/action
 | `wf-prepare-release.yaml` | `timezone` | string | no | IANA timezone to use when calculating the current date for the CHANGELOG. Defaults to `America/Los_Angeles`. |
 | `wf-finalize-release.yaml` | `draft` | boolean | no | If true (the default), mark the new release as a draft and require manual intervention to continue. |
 | `wf-finalize-release.yaml` | `attach-tarball` | boolean | no | If true (not the default), attach a tarball of the repository source, including all submodules, to the release. |
-| `wf-alias-release.yaml` | `commit_user_name` | string | no | User name to use while tagging new commits (defaults to `github-actions[bot]`) |
-| `wf-alias-release.yaml` | `commit_user_email` | string | no | User email to use while tagging new commits (defaults to `41898282+github-actions[bot]@users.noreply.github.com`) |
+| `wf-alias-release.yaml` | `commit-user-name` | string | no | User name to use while tagging new commits (defaults to `github-actions[bot]`) |
+| `wf-alias-release.yaml` | `commit-user-email` | string | no | User email to use while tagging new commits (defaults to `41898282+github-actions[bot]@users.noreply.github.com`) |
 
 All four workflows also accept a `token` secret which is required for full functionality (e.g. CI/CD checks on the opened pull request). The provided [personal access token](https://github.com/settings/tokens/new) should be stored as a secret in the repository and have the following scopes:
 

--- a/bumpchanges/finalize.py
+++ b/bumpchanges/finalize.py
@@ -109,6 +109,13 @@ class PreparedRelease(LoggingMixin):
         release_url = subprocess.check_output(args).decode("utf-8").strip()
         self.logger.log(NOTICE, "Release created at %s", release_url)
 
+        # Save the release's tag for following steps
+        with Path(os.environ["GITHUB_OUTPUT"]).open(
+            mode="w", encoding="utf-8"
+        ) as outfile:
+            # Write out a string with the artifact's name
+            outfile.write(f"RELEASE_TAG={self.tag}\n")
+
         # Post a comment linking to the new release
         comment_header = "*Bleep bloop, I am a robot.*"
         comment_body = textwrap.fill(

--- a/bumpchanges/finalize.py
+++ b/bumpchanges/finalize.py
@@ -191,6 +191,8 @@ def entrypoint():
         new_release = PreparedRelease.from_environment()
 
         archival_path = Path(args.archival_path) if args.archival_path else None
+        if archival_path and not archival_path.exists():
+            archival_path = None
 
         if archival_path:
             # Sanity-check that the cloned name matches the environment

--- a/templates/alias-release.yaml
+++ b/templates/alias-release.yaml
@@ -16,4 +16,5 @@ permissions:
 jobs:
   update-alias:
     uses: uclahs-cds/tool-create-release/.github/workflows/wf-alias-release.yaml@v1
-    secrets: inherit
+    secrets:
+      token: ${{ secrets.YOUR_PAT }}

--- a/templates/finalize-release.yaml
+++ b/templates/finalize-release.yaml
@@ -19,6 +19,8 @@ jobs:
   finalize-release:
     if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'automation-create-release') }}
     uses: uclahs-cds/tool-create-release/.github/workflows/wf-finalize-release.yaml@v1
-    secrets: inherit
     with:
       draft: false
+      attach-tarball: false
+    secrets:
+      token: ${{ secrets.YOUR_PAT }}

--- a/templates/prepare-release-non-semantic-version.yaml
+++ b/templates/prepare-release-non-semantic-version.yaml
@@ -22,4 +22,5 @@ jobs:
     with:
       bump_type: "exact"
       exact_version: ${{ inputs.version }}
-    secrets: inherit
+    secrets:
+      token: ${{ secrets.YOUR_PAT }}

--- a/templates/prepare-release.yaml
+++ b/templates/prepare-release.yaml
@@ -29,4 +29,5 @@ jobs:
     with:
       bump_type: ${{ inputs.bump_type }}
       prerelease: ${{ inputs.prerelease }}
-    secrets: inherit
+    secrets:
+      token: ${{ secrets.YOUR_PAT }}


### PR DESCRIPTION
# Description
Closes #28.

This PR has two intermixed changes that will necessitate a major version bump: attaching a source tarball to the releases and changing how `secrets` are handled.

The source tarball changes are relatively straightforward - I've added a new `attach-tarball` boolean argument (defaulting to false) to the finalize workflow. If set, the workflow clones the calling repository to `source/<repo-name>`. If that path exists then the `finalize-release` script creates a tarball, attaches it to the new release (which thankfully works even for drafts), and includes a note in the PR comment.

The `secrets` thing fell out of me trying properly handle the default and PAT tokens in the workflows. Rather than hard-coding our secret name (`UCLAHS_CDS_REPO_READ_TOKEN`), each workflow now has a `token` [`secrets` input](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets) that needs to be supplied like so:

```yaml
jobs:
  prepare-release:
    uses: uclahs-cds/tool-create-release/.github/workflows/wf-prepare-release.yaml@v1
    with:
      bump_type: ${{ inputs.bump_type }}
      prerelease: ${{ inputs.prerelease }}
    secrets:
      token: ${{ secrets.YOUR_PAT }}
```

Doing that will make this useful for organizations other than us, and is the correct way to do it, but it unfortunately does require rewriting a bunch of workflows - hence the need for a major version bump thereafter.

Here are several examples of this working in a testing repository:

* PR with draft release:
    * https://github.com/uclahs-cds/user-nwiltsie-pipeline/pull/46
    * https://github.com/uclahs-cds/user-nwiltsie-pipeline/releases/tag/v2.2.5
* PR with direct release:
    * https://github.com/uclahs-cds/user-nwiltsie-pipeline/pull/45
    * https://github.com/uclahs-cds/user-nwiltsie-pipeline/releases/tag/v2.2.4

Both of those releases have a `source_code_with_submodules.tar.gz` attachment (generated by the old workflow) and an identical `Source code with submodules (tar.gz)` (generated by the new workflow).

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
