### PR TITLE
Automatically delete release branch after merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Remove hard-coded UCLA secrets, add explicit `secrets` inputs to workflows
+- Automatically delete release branch after merging pull request
 
 ## [1.0.3] - 2024-11-01
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Usage of this tool requires adding three workflows to each calling repository (n
   * By default the new release is a draft, so no public release or tag are created without user intervention.
 1. Optionally, attach a source tarball including all submodules to the new release.
 1. Comment on the release PR with a link to the new release.
+1. Delete the merged release branch.
 
 ```mermaid
     gitGraph

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Parameters can be specified using the [`with`](https://docs.github.com/en/action
 | `wf-alias-release.yaml` | `commit-user-name` | string | no | User name to use while tagging new commits (defaults to `github-actions[bot]`) |
 | `wf-alias-release.yaml` | `commit-user-email` | string | no | User email to use while tagging new commits (defaults to `41898282+github-actions[bot]@users.noreply.github.com`) |
 
-All four workflows also accept a `token` secret which is required for full functionality (e.g. CI/CD checks on the opened pull request). The provided [personal access token](https://github.com/settings/tokens/new) should be stored as a secret in the repository and have the following scopes:
+All three workflows also accept a `token` secret which is required for full functionality (e.g. CI/CD checks on the opened pull request). The provided [personal access token](https://github.com/settings/tokens/new) should be stored as a secret in the repository and have the following scopes:
 
 * `repo`
 * `workflow`

--- a/bumpchanges/finalize.py
+++ b/bumpchanges/finalize.py
@@ -15,6 +15,7 @@ from typing import Optional
 from .logging import setup_logging, NOTICE, LoggingMixin
 from .utils import (
     decode_branch_name,
+    delete_branch,
     version_to_tag_str,
     tag_to_semver,
     str_to_bool,
@@ -206,3 +207,6 @@ def entrypoint():
     except:
         logging.getLogger(__name__).exception("Failed to create new release")
         raise
+
+    # Delete the branch
+    delete_branch(new_release.owner_repo, os.environ["GITHUB_HEAD_REF"])

--- a/bumpchanges/utils.py
+++ b/bumpchanges/utils.py
@@ -47,6 +47,32 @@ def decode_branch_name(branch: str) -> str:
     return version
 
 
+def delete_branch(owner_repo: str, branch: str):
+    """Delete a branch from GitHub by name. Gracefully handles failure."""
+    logger = logging.getLogger(__name__)
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "DELETE",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "-H",
+                "X-GitHub-Api-Version: 2022-11-28",
+                f"/repos/{owner_repo}/git/refs/heads/{branch}",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        logger.info("Deleted branch %s", branch)
+    except subprocess.CalledProcessError as err:
+        logger.info("Failed to delete branch %s", branch)
+        logger.info("Stdout: %s", err.stdout.decode("utf-8"))
+        logger.info("Stderr: %s", err.stderr.decode("utf-8"))
+
+
 def tag_to_semver(tag: str) -> semver.version.Version:
     """
     Return the Version associated with this git tag.


### PR DESCRIPTION
# Description

This is a little nicety that I'd like to slip in before bumping the major version (see #29). All this does is try to delete the release branch at the end of the release finalization workflow.

If the deletion fails (as in my example below where I deleted the branch manually) the workflow logs any error messages but does not fail.

### Successful Deletion
PR: https://github.com/uclahs-cds/user-nwiltsie-pipeline/pull/50
Workflow logs: https://github.com/uclahs-cds/user-nwiltsie-pipeline/actions/runs/13015993703/job/36305213472#step:8:18
```
Deleted branch automation-create-release-2.3.1
```
<img width="621" alt="SCR-20250128-ivpk" src="https://github.com/user-attachments/assets/b7cd146d-8760-48a6-a583-05346175b980" />

### Unsuccessful Deletion
PR: https://github.com/uclahs-cds/user-nwiltsie-pipeline/pull/51
Workflow logs: https://github.com/uclahs-cds/user-nwiltsie-pipeline/actions/runs/13016071577/job/36305465966#step:8:180
```
Failed to delete branch automation-create-release-2.3.2
Stdout: {"message":"Reference does not exist","documentation_url":"https://docs.github.com/rest/git/refs#delete-a-reference","status":"422"}
Stderr: gh: Reference does not exist (HTTP 422)
```
<img width="618" alt="SCR-20250128-ivuc" src="https://github.com/user-attachments/assets/2a8c7a66-94dc-43cb-9398-e1d273893af3" />

### Closes #27 

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
