### PR TITLE
Handle behavioral change with mdformat v0.7.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove hard-coded UCLA secrets, add explicit `secrets` inputs to workflows
 - Automatically delete release branch after merging pull request
 
+### Fixed
+
+- Added `import mdformat.renderer` to fix issue with mdformat v0.7.22
+
 ## [1.0.3] - 2024-11-01
 
 ### Fixed

--- a/bumpchanges/changelog.py
+++ b/bumpchanges/changelog.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import ClassVar, Optional
 
 import mdformat
+import mdformat.renderer
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
 


### PR DESCRIPTION
# Description
Something about [the changes between mdformat 0.7.21 and 0.7.22](https://github.com/hukkin/mdformat/compare/0.7.21...0.7.22) caused the code updating the CHANGELOG to throw an error:

```console
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.16/x64/bin/bump-changelog", line 8, in <module>
    sys.exit(bump.entrypoint())
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/bumpchanges/bump.py", line 113, in entrypoint
    update_changelog(args.changelog, args.repo_url, args.version, now_date)
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/bumpchanges/bump.py", line 30, in update_changelog
    changelog_file.write_text(changelog.render(), encoding="utf-8")
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/bumpchanges/changelog.py", line 400, in render
    renderer = mdformat.renderer.MDRenderer()
AttributeError: module 'mdformat' has no attribute 'renderer'
Error: Process completed with exit code 1.
```

Adding in an explicit `import mdformat.renderer` fixes the issue (and is backwards-compatible).

### Closes #...  <!-- edit if this PR closes an Issue -->

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
