### PR TITLE
Prepare for version `1.0.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.0.4] - 2025-02-10
 
 ### Fixed
 
@@ -103,3 +103,4 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [1.0.1]: https://github.com/uclahs-cds/tool-create-release/compare/v1.0.0...v1.0.1
 [1.0.2]: https://github.com/uclahs-cds/tool-create-release/compare/v1.0.1...v1.0.2
 [1.0.3]: https://github.com/uclahs-cds/tool-create-release/compare/v1.0.2...v1.0.3
+[1.0.4]: https://github.com/uclahs-cds/tool-create-release/compare/v1.0.3...v1.0.4


### PR DESCRIPTION
Update CHANGELOG in preparation for release **1.0.4**.

Merging this PR will trigger another workflow to create the release tag **v1.0.4**.

| Input | Value |
| ----- | ----- |
| Actor | @nwiltsie |
| Branch | `hotfix` |
| Bump Type | `patch` |
