### PR TITLE
Allow prefix characters in versionfile regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Update version file regex to allow leading characters, like `Plugin-Version`
+
 ## [1.1.0] - 2025-02-10
 
 ### Fixed
 
-- Added `import mdformat.renderer` to fix issue with mdformat v0.7.22
+- Add `import mdformat.renderer` to fix issue with mdformat v0.7.22
 
 ## [1.0.3] - 2024-11-01
 

--- a/bumpchanges/updatefiles.py
+++ b/bumpchanges/updatefiles.py
@@ -15,6 +15,7 @@ VERSION_REGEX = re.compile(
     (?P<prefix>             # Open `prefix` capture group
         \s*                 # Any whitespace
         (?P<vquote>['"]?)   # `'`, `"`, or nothing (saved as `vquote` group)
+        (?:\w+?-?)?         # Optional word characters and optional literal `-`
         (?:__)?             # Optional literal `__`
         version             # Literal `version`
         (?:__)?             # Optional literal `__`

--- a/bumpchanges/updatefiles.py
+++ b/bumpchanges/updatefiles.py
@@ -15,7 +15,10 @@ VERSION_REGEX = re.compile(
     (?P<prefix>             # Open `prefix` capture group
         \s*                 # Any whitespace
         (?P<vquote>['"]?)   # `'`, `"`, or nothing (saved as `vquote` group)
-        (?:\w+?-?)?         # Optional word characters and optional literal `-`
+        (?:                 # Open optional unnamed word prefix group
+            (?!Manifest-)   # Negative lookahead to not match Manifest-Version
+            \w+?-?          # Word characters and optional literal `-`
+        )?
         (?:__)?             # Optional literal `__`
         version             # Literal `version`
         (?:__)?             # Optional literal `__`

--- a/tests/test_versionfiles.py
+++ b/tests/test_versionfiles.py
@@ -84,6 +84,16 @@ version_strings = [
         """version 90304""",
         """version 2.3.4""",
     ),
+    (
+        # Leading prefix
+        """PluginVersion: 0.6.0""",
+        """PluginVersion: 2.3.4""",
+    ),
+    (
+        # Leading prefix and dash
+        """Plugin-Version: 0.6.0""",
+        """Plugin-Version: 2.3.4""",
+    ),
 ]
 
 

--- a/tests/test_versionfiles.py
+++ b/tests/test_versionfiles.py
@@ -94,6 +94,19 @@ version_strings = [
         """Plugin-Version: 0.6.0""",
         """Plugin-Version: 2.3.4""",
     ),
+    (
+        # Almost but-not-quite Manifest-Version
+        """anifest-Version: 0.6.0""",
+        """anifest-Version: 2.3.4""",
+    ),
+]
+
+
+# A list of version-like strings that will _not_ be matched.
+unmatched_strings = [
+    # Java JAR manifest version
+    "Manifest-Version: 1.0",
+    "manifest-version: 1.0",
 ]
 
 
@@ -107,3 +120,15 @@ def test_version_updates(tmp_path, original, expected):
     version_file.write_text(original, encoding="utf-8")
     update_file(version, version_file)
     assert version_file.read_text(encoding="utf-8") == expected
+
+@pytest.mark.parametrize("unmatched_line", unmatched_strings)
+def test_negative_matches(tmp_path, unmatched_line):
+    """Confirm that the invalid version paths are _not_ matched."""
+    version = "2.3.4"
+
+    # Test the text alone (no trailing newline
+    version_file = tmp_path / "version.txt"
+    version_file.write_text(unmatched_line, encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        update_file(version, version_file)


### PR DESCRIPTION
# Description
This updates the regex used to match/update hard-coded version strings in files to allow optional leading characters and a `-` before `version` (with the hard-coded exception of `Manifest-`, which will never match)..

Specifically I want to use this action to manage Nextflow plugins, which include a `MANIFEST.MF` file with a format like this:

```
Manifest-Version: 1.0
Plugin-Class: the.plugin.ClassName
Plugin-Id: the-plugin-id
Plugin-Provider: Your Name or Organization
Plugin-Version: 0.0.0
```

That `Manifest-Version` is the [version of the manifest file format itself](https://docs.oracle.com/en/java/javase/14/docs/specs/jar/jar.html#main-attributes) and seems to have always been `1.0`, while `Plugin-Version` is the one I want to update.

I added tests that `Plugin-Version` and `anifest-Version` are matched and `Manifest-Version` is not.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
